### PR TITLE
Replacing "private_networking" argument

### DIFF
--- a/dcos.tf
+++ b/dcos.tf
@@ -7,10 +7,10 @@ resource "digitalocean_droplet" "dcos_bootstrap" {
   
   image = "coreos-stable"
   size             = "${var.boot_size}"
+    private_networking = true
     ssh_keys = ["${var.ssh_key_fingerprint}"]
   connection {
     user = "core"
-    private_networking = true
     private_key = "${file(var.dcos_ssh_key_path)}"
   }
   user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"


### PR DESCRIPTION
As "private_networking" argument is within the connection, it's raising an error digitalocean_droplet.dcos_bootstrap: unknown 'connection' argument "private_networking". To fix this error, I've moved the private_networking argument from the connection loop.