### PR TITLE
Compliant with terraform 0.9+, terraform fmt, nyc2 full

### DIFF
--- a/dcos.tf
+++ b/dcos.tf
@@ -4,136 +4,161 @@ provider "digitalocean" {
 
 resource "digitalocean_droplet" "dcos_bootstrap" {
   name = "${format("${var.dcos_cluster_name}-bootstrap-%02d", count.index)}"
-  
-  image = "coreos-stable"
-  size             = "${var.boot_size}"
-    ssh_keys = ["${var.ssh_key_fingerprint}"]
+
+  image    = "coreos-stable"
+  size     = "${var.boot_size}"
+  ssh_keys = ["${var.ssh_key_fingerprint}"]
+
+  private_networking = true
+
   connection {
-    user = "core"
-    private_networking = true
+    user        = "core"
     private_key = "${file(var.dcos_ssh_key_path)}"
   }
-  user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
-  region      = "${var.region}"
+
+  user_data = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
+  region    = "${var.region}"
 
   provisioner "local-exec" {
     command = "rm -rf ./do-install.sh"
   }
+
   provisioner "local-exec" {
     command = "echo BOOTSTRAP=\"${digitalocean_droplet.dcos_bootstrap.ipv4_address}\" >> ips.txt"
   }
+
   provisioner "local-exec" {
     command = "echo CLUSTER_NAME=\"${var.dcos_cluster_name}\" >> ips.txt"
-  }  
+  }
+
   provisioner "remote-exec" {
-  inline = [
-    "wget -q -O dcos_generate_config.sh -P $HOME ${var.dcos_installer_url}",
-    "mkdir $HOME/genconf"
+    inline = [
+      "wget -q -O dcos_generate_config.sh -P $HOME ${var.dcos_installer_url}",
+      "mkdir $HOME/genconf",
     ]
   }
+
   provisioner "local-exec" {
     command = "./make-files.sh"
   }
+
   provisioner "local-exec" {
     command = "sed -i -e '/^- *$/d' ./config.yaml"
   }
+
   provisioner "file" {
-    source = "./ip-detect"
+    source      = "./ip-detect"
     destination = "$HOME/genconf/ip-detect"
   }
+
   provisioner "file" {
-    source = "./config.yaml"
+    source      = "./config.yaml"
     destination = "$HOME/genconf/config.yaml"
   }
+
   provisioner "remote-exec" {
-    inline = ["sudo bash $HOME/dcos_generate_config.sh",
-              "docker run -d -p 4040:80 -v $HOME/genconf/serve:/usr/share/nginx/html:ro nginx 2>/dev/null",
-              "docker run -d -p 2181:2181 -p 2888:2888 -p 3888:3888 --name=dcos_int_zk jplock/zookeeper 2>/dev/null"
-              ]
+    inline = [
+      "sudo bash $HOME/dcos_generate_config.sh",
+      "docker run -d -p 4040:80 -v $HOME/genconf/serve:/usr/share/nginx/html:ro nginx 2>/dev/null",
+      "docker run -d -p 2181:2181 -p 2888:2888 -p 3888:3888 --name=dcos_int_zk jplock/zookeeper 2>/dev/null",
+    ]
   }
 }
 
 resource "digitalocean_droplet" "dcos_master" {
-  name = "${format("${var.dcos_cluster_name}-master-%02d", count.index)}"
+  name  = "${format("${var.dcos_cluster_name}-master-%02d", count.index)}"
   image = "coreos-stable"
-  size             = "${var.master_size}"
+  size  = "${var.master_size}"
 
   ssh_keys = ["${var.ssh_key_fingerprint}"]
 
-  count         = "${var.dcos_master_count}"
-  user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
-  region      = "${var.region}"
-    private_networking = true
+  count              = "${var.dcos_master_count}"
+  user_data          = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
+  region             = "${var.region}"
+  private_networking = true
+
   connection {
-    user = "core"
+    user        = "core"
     private_key = "${file(var.dcos_ssh_key_path)}"
   }
+
   provisioner "local-exec" {
     command = "rm -rf ./do-install.sh"
   }
+
   provisioner "local-exec" {
     command = "echo ${format("MASTER_%02d", count.index)}=\"${self.ipv4_address}\" >> ips.txt"
   }
+
   provisioner "local-exec" {
     command = "while [ ! -f ./do-install.sh ]; do sleep 1; done"
   }
+
   provisioner "file" {
-    source = "./do-install.sh"
+    source      = "./do-install.sh"
     destination = "/tmp/do-install.sh"
   }
+
   provisioner "remote-exec" {
     inline = "bash /tmp/do-install.sh master"
   }
 }
 
 resource "digitalocean_droplet" "dcos_agent" {
-  name = "${format("${var.dcos_cluster_name}-agent-%02d", count.index)}"
-  depends_on = ["digitalocean_droplet.dcos_bootstrap"]
-  image = "coreos-stable"
-  size          = "${var.agent_size}"
-  count         = "${var.dcos_agent_count}"
-  user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
-  region      = "${var.region}"
-    private_networking = true
-  ssh_keys = ["${var.ssh_key_fingerprint}"]
+  name               = "${format("${var.dcos_cluster_name}-agent-%02d", count.index)}"
+  depends_on         = ["digitalocean_droplet.dcos_bootstrap"]
+  image              = "coreos-stable"
+  size               = "${var.agent_size}"
+  count              = "${var.dcos_agent_count}"
+  user_data          = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
+  region             = "${var.region}"
+  private_networking = true
+  ssh_keys           = ["${var.ssh_key_fingerprint}"]
+
   connection {
-    user = "core"
+    user        = "core"
     private_key = "${file(var.dcos_ssh_key_path)}"
   }
+
   provisioner "local-exec" {
     command = "while [ ! -f ./do-install.sh ]; do sleep 1; done"
   }
+
   provisioner "file" {
-    source = "do-install.sh"
+    source      = "do-install.sh"
     destination = "/tmp/do-install.sh"
   }
+
   provisioner "remote-exec" {
     inline = "bash /tmp/do-install.sh slave"
   }
 }
 
-
 resource "digitalocean_droplet" "dcos_public_agent" {
-  name = "${format("${var.dcos_cluster_name}-public-agent-%02d", count.index)}"
-  depends_on = ["digitalocean_droplet.dcos_bootstrap"]
-  image = "coreos-stable"
-  size          = "${var.agent_size}"
-  count         = "${var.dcos_public_agent_count}"
-  user_data     = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
-  region      = "${var.region}"
-    private_networking = true
-  ssh_keys = ["${var.ssh_key_fingerprint}"]
+  name               = "${format("${var.dcos_cluster_name}-public-agent-%02d", count.index)}"
+  depends_on         = ["digitalocean_droplet.dcos_bootstrap"]
+  image              = "coreos-stable"
+  size               = "${var.agent_size}"
+  count              = "${var.dcos_public_agent_count}"
+  user_data          = "#cloud-config\n\nssh_authorized_keys:\n  - \"${file("${var.dcos_ssh_public_key_path}")}\"\n"
+  region             = "${var.region}"
+  private_networking = true
+  ssh_keys           = ["${var.ssh_key_fingerprint}"]
+
   connection {
-    user = "core"
+    user        = "core"
     private_key = "${file(var.dcos_ssh_key_path)}"
   }
+
   provisioner "local-exec" {
     command = "while [ ! -f ./do-install.sh ]; do sleep 1; done"
   }
+
   provisioner "file" {
-    source = "do-install.sh"
+    source      = "do-install.sh"
     destination = "/tmp/do-install.sh"
   }
+
   provisioner "remote-exec" {
     inline = "bash /tmp/do-install.sh slave_public"
   }

--- a/output.tf
+++ b/output.tf
@@ -1,12 +1,15 @@
 output "agent-ip" {
   value = "${join(",", digitalocean_droplet.dcos_agent.*.ipv4_address)}"
 }
+
 output "agent-public-ip" {
   value = "${join(",", digitalocean_droplet.dcos_public_agent.*.ipv4_address)}"
 }
+
 output "master-ip" {
   value = "${join(",", digitalocean_droplet.dcos_master.*.ipv4_address)}"
 }
+
 output "bootstrap-ip" {
   value = "${digitalocean_droplet.dcos_bootstrap.ipv4_address}"
 }

--- a/sample.terraform.tfvars
+++ b/sample.terraform.tfvars
@@ -1,6 +1,6 @@
 digitalocean_token = ""
 
-region = "NYC2"
+region = "nyc3"
 
 master_size = "4GB"
 

--- a/vars.tf
+++ b/vars.tf
@@ -1,4 +1,3 @@
-
 variable "digitalocean_token" {
   description = "Your DigitalOcean API key"
 }
@@ -9,55 +8,55 @@ variable "ssh_key_fingerprint" {
 
 variable "region" {
   description = "DigitalOcean Region"
-  default = "NYC2"
+  default     = "nyc3"
 }
 
 variable "agent_size" {
   description = "DCOS Agent Droplet Size"
-  default = "4GB"
+  default     = "4GB"
 }
 
 variable "master_size" {
   description = "DCOS Master Droplet Size"
-  default = "4GB"
+  default     = "4GB"
 }
 
 variable "boot_size" {
   description = "DCOS Boot Server Droplet Size"
-  default = "4GB"
+  default     = "4GB"
 }
 
 variable "dcos_cluster_name" {
   description = "Name of your cluster. Alpha-numeric and hyphens only, please."
-  default = "digitalocean-dcos"
+  default     = "digitalocean-dcos"
 }
 
 variable "dcos_master_count" {
-  default = "3"
+  default     = "3"
   description = "Number of master nodes. 1, 3, or 5."
 }
 
 variable "dcos_agent_count" {
   description = "Number of agents to deploy"
-  default = "4"
+  default     = "4"
 }
 
 variable "dcos_public_agent_count" {
   description = "Number of public agents to deploy"
-  default = "1"
+  default     = "1"
 }
 
 variable "dcos_ssh_public_key_path" {
   description = "Path to your public SSH key path"
-  default = "./do-key.pub"
+  default     = "./do-key.pub"
 }
 
 variable "dcos_installer_url" {
   description = "Path to get DCOS"
-  default = "https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh"
+  default     = "https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh"
 }
 
 variable "dcos_ssh_key_path" {
   description = "Path to your private SSH key for the project"
-  default = "./do-key"
+  default     = "./do-key"
 }


### PR DESCRIPTION
Thanks for this great job! Less than 15 minutes to setup a DC/OS testing environment \o/

3 updates:

`dcos.tf` (resource `digitalocean_droplet.dcos_bootstrap`) expects `private_networking = true` to be outside `connection` stanza in terraform 0.9 and more.

NYC2 datacenter is now full at DigitalOcean => default DC to NYC3

I executed `$ terraform fmt` for cleaning up your code ;)